### PR TITLE
Remove extents call from linear/log scale

### DIFF
--- a/src/wadogo/scale.clj
+++ b/src/wadogo/scale.clj
@@ -15,7 +15,9 @@
             [wadogo.scale.threshold]
             [wadogo.scale.histogram]
             [wadogo.scale.datetime]
-            [wadogo.scale.constant])
+            [wadogo.scale.constant]
+            
+            [fastmath.stats :as stats])
   (:import [wadogo.common ScaleType]))
 
 (set! *warn-on-reflection* true)
@@ -73,6 +75,10 @@
      (if (= range-or-domain :domain)
        (general-size (domain scale) dtype)
        (general-size (range scale) rtype)))))
+
+(defn extent [xs]
+  (let [[minx maxx] (stats/extent xs)]
+    [minx maxx]))
 
 (comment
 

--- a/src/wadogo/scale/linear.clj
+++ b/src/wadogo/scale/linear.clj
@@ -14,8 +14,8 @@
   ([_] (scale :linear {}))
   ([_ params]
    (let [params (merge default-params params)
-         [dstart dend] (stats/extent (:domain params))
-         [rstart rend] (stats/extent (:range params))]
+         [dstart dend] (:domain params)
+         [rstart rend] (:range params)]
      (->ScaleType :linear (:domain params) (:range params) (:ticks params) (:fmt params)
                   (make-norm dstart dend rstart rend)
                   (make-norm rstart rend dstart dend)

--- a/src/wadogo/scale/log.clj
+++ b/src/wadogo/scale/log.clj
@@ -28,8 +28,8 @@
   ([_] (scale :log {}))
   ([_ params]
    (let [params (merge default-params params)
-         [^double dstart ^double dend] (stats/extent (:domain params))
-         [rstart rend] (stats/extent (:range params))
+         [^double dstart ^double dend] (:domain params)
+         [rstart rend] (:range params)
          n? (neg? dstart)
          ls (m/log (if n? (- dstart) dstart))
          le (m/log (if n? (- dend) dend))]

--- a/test/wadogo/scale/linear_test.clj
+++ b/test/wadogo/scale/linear_test.clj
@@ -68,3 +68,8 @@
     (is (m/nan? (l ##NaN)))
     (is (= (l ##Inf) ##Inf))
     (is (= (l ##-Inf) ##-Inf))))
+
+(deftest descending-range
+  (let [l (s/scale :linear {:domain [0 1] :range [100 0]})]
+    (is (= (l 1) 0.0))
+    (is (= (l 0) 100.0))))

--- a/test/wadogo/scale/log_test.clj
+++ b/test/wadogo/scale/log_test.clj
@@ -37,3 +37,8 @@
       (is (m/approx-eq (s/inverse l 0.5849625) 1.5))
       (is (m/approx-eq (s/inverse l 1.0) 2.0))
       (is (m/approx-eq (s/inverse l 1.3219281) 2.5)))))
+
+(deftest descending-range-log-scale
+  (let [l (s/scale :log {:domain [1 10] :range [10 1]})]
+    (is (= (l 10) 1.0))
+    (is (= (l 1) 10.0))))


### PR DESCRIPTION
The extent calls in log and linear scale implementations enable sequences to be passed as domain/range, and the min/max is used. As implemented, this didn't allow for "descending scales" where the range is from X to a lesser number. 

As discussed on zulip, I removed the `stats/extent` calls in these scale implementations and added `extent` to `wadogo.scale` as a helper function.